### PR TITLE
fix edge-case where "OK" gets parsed as the response lenght

### DIFF
--- a/gps.py
+++ b/gps.py
@@ -244,7 +244,9 @@ class SIM7080G:
             self._send_at_command(command=json_string + '\n', regex_return_filter='^\+SHREQ.+')
 
             logger.debug("(POST) POSTing data...")
-            post_result = self._send_at_command(command='AT+SHREQ="/post-echo.php",3')
+            post_result = self._send_at_command(command='AT+SHREQ="/post-echo.php",3',
+                                                expected_reply_regex='^\+SHREQ: \"POST\",\d{3},\d{1,4}$',
+                                                regex_return_filter='^\+SHREQ: \"POST\",\d{3},\d{1,4}$')
             post_resp_size = post_result.split(',')[-1]
 
             # read http response


### PR DESCRIPTION
This fixes a race issue where "OK" is mistakenly read as the byte length of the HTTP POST response

Before:
```
2023-11-03 23:05:55 - DEBUG: (POST) POSTing data...
2023-11-03 23:05:55 - DEBUG: Sending data to serial interface: "AT+SHREQ="/post-echo.php",3"
2023-11-03 23:05:56 - DEBUG: Parsing response data. Attempt 1 of 5...
2023-11-03 23:05:56 - DEBUG: Attempting read from serial interface...
2023-11-03 23:05:56 - DEBUG: Found 34 bytes waiting on serial output
2023-11-03 23:05:56 - DEBUG: AT command response data (untouched)
---- BEGIN ----
AT+SHREQ="/post-echo.php",3
OK

---- END ----
2023-11-03 23:05:56 - DEBUG: Response matches expected reply regex: "^OK$". Returning data filtered with regex: ".*".
2023-11-03 23:05:56 - DEBUG: AT command response data (after regex filter)
---- BEGIN ----
OK
---- END ----
2023-11-03 23:05:56 - DEBUG: (POST) Reading HTTP reply...
2023-11-03 23:05:56 - DEBUG: Sending data to serial interface: "AT+SHREAD=0,OK"
2023-11-03 23:05:56 - DEBUG: Parsing response data. Attempt 1 of 5...
2023-11-03 23:05:56 - DEBUG: Attempting read from serial interface...
2023-11-03 23:05:56 - DEBUG: Found 50 bytes waiting on serial output
2023-11-03 23:05:56 - DEBUG: AT command response data (untouched)
---- BEGIN ----
AT+SHREAD=0,OK
ERROR

+SHREQ: "POST",200,569
```

After:
```
2023-11-03 23:37:41 - DEBUG: (POST) POSTing data...
2023-11-03 23:37:41 - DEBUG: Sending data to serial interface: "AT+SHREQ="/post-echo.php",3"
2023-11-03 23:37:41 - DEBUG: Attempting read from serial interface...
2023-11-03 23:37:41 - DEBUG: Found 34 bytes waiting on serial output
2023-11-03 23:37:41 - DEBUG: AT command response data (untouched)
---- BEGIN ----
AT+SHREQ="/post-echo.php",3
OK

---- END ----
2023-11-03 23:37:41 - DEBUG: Parsing response data. Attempt 1 of 5 to find expected response...
2023-11-03 23:37:43 - DEBUG: Attempting read from serial interface...
2023-11-03 23:37:43 - DEBUG: Found 26 bytes waiting on serial output
2023-11-03 23:37:43 - DEBUG: AT command response data (untouched)
---- BEGIN ----

+SHREQ: "POST",200,569

---- END ----
2023-11-03 23:37:43 - DEBUG: Parsing response data. Attempt 2 of 5 to find expected response...
2023-11-03 23:37:43 - DEBUG: Response matches expected reply regex: "^\+SHREQ: "POST",\d{3},\d{1,4}$". Returning data filtered with regex: "^\+SHREQ: "POST",\d{3},\d{1,4}$".
2023-11-03 23:37:43 - DEBUG: AT command response data (after regex filter)
---- BEGIN ----
+SHREQ: "POST",200,569
---- END ----
2023-11-03 23:37:43 - DEBUG: (POST) Reading HTTP reply...
2023-11-03 23:37:43 - DEBUG: Sending data to serial interface: "AT+SHREAD=0,569"
2023-11-03 23:37:44 - DEBUG: Attempting read from serial interface...
2023-11-03 23:37:44 - DEBUG: Found 609 bytes waiting on serial output
2023-11-03 23:37:44 - DEBUG: AT command response data (untouched)
---- BEGIN ----
AT+SHREAD=0,569
OK

+SHREAD: 569
{"headers":{"Host":"paglusch.com"........
```